### PR TITLE
Add model metadata that is default uneditable

### DIFF
--- a/topmodel/model_data.py
+++ b/topmodel/model_data.py
@@ -19,6 +19,7 @@ SCORES_BM_FILE = 'scores_bm.tsv'
 
 HISTOGRAM_FILE = 'histogram.json'
 NOTES_FILE = "notes.txt"
+METATDATA_FILE = "metadata.txt"
 
 BIN_COUNT = 100
 
@@ -182,6 +183,10 @@ class ModelData(object):
             df.to_csv(f, sep='\t', index=False)
             scores_path = os.path.join(self.model_path, SCORES_FILE)
             self.file_system.write_file(scores_path, f.getvalue())
+
+    def get_metadata(self):
+        metadata_path = os.path.join(self.model_path, METATDATA_FILE)
+        return self.file_system.read_file(metadata_path)
 
     def get_notes(self):
         notes_path = os.path.join(self.model_path, NOTES_FILE)

--- a/web/templates/results_layout.html
+++ b/web/templates/results_layout.html
@@ -30,6 +30,10 @@
     <div id="preview" class="col-md-12">
     </div>
   </div>
+  <div class="col-md-6">
+    <h2> Model metadata</h2>
+      <pre>{% if model_metadata %}{{model_metadata|safe}}{% endif %}</pre>
+  </div>
 </div>
 
 <script src="/static/markdown.min.js"></script>

--- a/web/views/pages.py
+++ b/web/views/pages.py
@@ -51,6 +51,7 @@ def training(path):
 
         'auc': auc(cached_data[0]['fprs'], cached_data[0]['recalls']),
         'notes': model_data.get_notes(),
+        'model_metadata': model_data.get_metadata(),
         'path': path,
     }
     return render_template("results.html", **context)


### PR DESCRIPTION
r? @mlmanapat 

This shows information from a `metadata.txt` file below the model notes and doesn't provide the option to edit it. Information about the model that you don't want to accidentally overwrite can be stored in `metadata.txt` and `notes.txt` can stay for comments written by humans.