### PR TITLE
fix bootstrapping procedure

### DIFF
--- a/topmodel/model_data.py
+++ b/topmodel/model_data.py
@@ -154,11 +154,13 @@ class ModelData(object):
 
             for i in range(THRESHOLD_BINS):
                 probs.append((bin_edges[i] + bin_edges[i + 1]) / 2)
-                o_count.append(np.count_nonzero(
-                               ((predicted >= bin_edges[i]) & (predicted <= bin_edges[i + 1])) & actual))
-                f_count.append(np.count_nonzero(
-                               ((predicted >= bin_edges[i]) & (predicted <= bin_edges[i + 1]))))
-            # the probabilities, the number of true, and the total number
+                o_count.append(
+                    np.count_nonzero(
+                        ((predicted >= bin_edges[i]) & (predicted <= bin_edges[i + 1])) & actual))
+                f_count.append(
+                    np.count_nonzero(
+                        ((predicted >= bin_edges[i]) & (predicted <= bin_edges[i + 1]))))
+
             ret = {'probs': probs, 'trues': o_count, 'totals': f_count}
 
             # Cache the histogram info if this isn't a bootstrap resample:

--- a/topmodel/model_data.py
+++ b/topmodel/model_data.py
@@ -95,11 +95,14 @@ class ModelData(object):
             }
 
         base = metrics_from_hist(hist)
-        bootstrapped = []
-        for _ in xrange(n_bootstrap_samples):
-            resampled_hist = self.to_histogram_format(resample=True)
-            bootstrapped.append(metrics_from_hist(resampled_hist))
-        return [base] + bootstrapped
+        if n_bootstrap_samples == 0:
+            return base
+        else:
+            bootstrapped = []
+            for _ in xrange(n_bootstrap_samples):
+                resampled_hist = self.to_histogram_format(resample=True)
+                bootstrapped.append(metrics_from_hist(resampled_hist))
+            return [base] + bootstrapped
 
     def check_alt_format(self):
         # alternate data format is "score,trues,falses"


### PR DESCRIPTION
r? @roban (prep for when we talk about benchmarking later this week)

Previously, the code to do the precision/recall bootstrapping was:
* for each bin in the scores histogram:
    * re-sample the number of "trues" in that bin from a Poisson distribution with lambda=[original # trues]
    * set the number of "falses" in that bin to "bin total - resampled # of trues"
* re-calculate precision and recall based on the new counts (from this bin sampling)
* repeat N times (so you get N light precision/recall curves and an estimate of uncertainty)

I'm not really sure why the resample was done this way (I've never seen that approach before, and it doesn't allow for much extensibility, e.g., measuring uncertainty around metrics other than precision/recall/sensitivity/specificity). A more standard approach to bootstrapping is to resample the whole benchmark data set with replacement, then recalculate any desired metrics. This PR does that.