### PR TITLE
stop prefixing with subdirectory in list functions

### DIFF
--- a/topmodel/file_system.py
+++ b/topmodel/file_system.py
@@ -58,12 +58,14 @@ class S3FileSystem(FileSystem):
         key.set_contents_from_string(data)
 
     def list(self, path=''):
-        return [key.name for key in self.bucket.list(self.subdirectory + path)]
+        subdirlen = len(self.subdirectory)
+        return [key.name[subdirlen:] for key in self.bucket.list(self.subdirectory + path)]
 
     def list_name_modified(self, path=''):
         model_names_and_modified = {}
+        subdirlen = len(self.subdirectory)
         for key in self.bucket.list(self.subdirectory + path):
-            model_names_and_modified[key.name] = key.last_modified
+            model_names_and_modified[key.name[subdirlen:]] = key.last_modified
         return model_names_and_modified
 
     def remove(self, path):


### PR DESCRIPTION
r? @jocelynsarah 

I believe this is the actual fix for the subdirectory problems we were investigating on Friday. Basically this makes it so that `list`ing the models will never include the subdirectory, which I think makes sense if you want to host your whole page in a subdirectory (you shouldn't necessarily have to remember that after you call the `list` functions).

Tested on QA and it seems to work (the `notify` endpoint is no longer repopulating the database with new models prefixed with the subdirectory \o/)