### PR TITLE
topmodel: use raw connect_to_region to improve file transfers

### DIFF
--- a/config_example.yaml
+++ b/config_example.yaml
@@ -1,3 +1,4 @@
 bucket: your-bucket
 aws_secret_key: your-secret-key
 aws_access_key: your-access-key
+region: 'us-west-2'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='topmodel',
-      version='0.1.2',
+      version='0.2.0',
       description='Model evaluation',
       author='Julia Evans',
       author_email='julia@stripe.com',

--- a/topmodel/file_system.py
+++ b/topmodel/file_system.py
@@ -5,9 +5,10 @@ import subprocess
 import time
 
 # for s3 from python
-from boto.s3.connection import S3Connection
+from boto.s3 import connect_to_region
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_REGION = 'us-west-2'
 
 
 class FileSystem(object):
@@ -34,12 +35,15 @@ class S3FileSystem(FileSystem):
                  bucket_name,
                  aws_access_key_id,
                  aws_secret_access_key,
-                 security_token=None,
+                 region,
                  subdirectory=''):
-        conn = S3Connection(
-            aws_access_key_id=aws_access_key_id,
-            aws_secret_access_key=aws_secret_access_key,
-            security_token=security_token)
+        if region is None:
+            region = DEFAULT_REGION
+
+        conn = connect_to_region(
+                region,
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key)
         self.bucket = conn.get_bucket(bucket_name)
         self.subdirectory = subdirectory
         if subdirectory and not subdirectory.endswith('/'):

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -21,7 +21,8 @@ def before_request():
         config = settings.read_config('./config.yaml')
         g.file_system = S3FileSystem(config['bucket'],
                                      config['aws_access_key'],
-                                     config['aws_secret_key'])
+                                     config['aws_secret_key'],
+                                     config['region'])
     g.model_data_manager = ModelDataManager(g.file_system)
 
 import web.views.pages


### PR DESCRIPTION
### What's in here

This PR uses `connect_to_region` to reduce the number of 104 Connection Reset by Peer errors we are seeing with training data uploads. This is a known workaround when using `boto` on 14.04: https://github.com/boto/boto/issues/2207.