### PR TITLE
topmodel: use multipart uploads for S3FileSystem

### DIFF
--- a/topmodel/file_system.py
+++ b/topmodel/file_system.py
@@ -58,14 +58,15 @@ class S3FileSystem(FileSystem):
         if key is None:
             key = self.bucket.new_key(self.subdirectory + path)
 
-        # Take the data (a giant string of JSON), and turn it into a file
-        # stream we can read from
+        # Take the data (a giant string), and turn it into a file IO stream
+        # we can read from
         f = StringIO.StringIO()
         f.write(data)
         f.seek(0)
 
         # Count the number of chunks we're going to have to upload
         size = len(data)
+        # By default, set the chunk size to 50MB
         chunk_size = 1024 * 1024 * 50
         chunks = int(math.ceil(size/float(chunk_size)))
 

--- a/topmodel/file_system.py
+++ b/topmodel/file_system.py
@@ -1,5 +1,7 @@
 # File abstraction to allow both S3 and local to be used
 
+import StringIO
+import math
 import os
 import subprocess
 import time
@@ -55,7 +57,31 @@ class S3FileSystem(FileSystem):
         key = self.bucket.get_key(self.subdirectory + path)
         if key is None:
             key = self.bucket.new_key(self.subdirectory + path)
-        key.set_contents_from_string(data)
+
+        # Take the data (a giant string of JSON), and turn it into a file
+        # stream we can read from
+        f = StringIO.StringIO()
+        f.write(data)
+        f.seek(0)
+
+        # Count the number of chunks we're going to have to upload
+        size = len(data)
+        chunk_size = 1024 * 1024 * 50
+        chunks = int(math.ceil(size/float(chunk_size)))
+
+        # Start the multipart upload
+        upload = self.bucket.initiate_multipart_upload(key)
+
+        try:
+            # Upload chunk by chunk, using the StringIO object instantiated above
+            # we can reference the offset we want to upload.
+            for i in range(chunks):
+                upload.upload_part_from_file(f, part_num=i+1)
+        except:
+            upload.cancel_upload()
+            raise
+        else:
+            upload.complete_upload()
 
     def list(self, path=''):
         subdirlen = len(self.subdirectory)

--- a/topmodel/file_system.py
+++ b/topmodel/file_system.py
@@ -76,7 +76,8 @@ class S3FileSystem(FileSystem):
             # Upload chunk by chunk, using the StringIO object instantiated above
             # we can reference the offset we want to upload.
             for i in range(chunks):
-                upload.upload_part_from_file(f, part_num=i+1)
+                bytes = min(chunk_size, size - (i * chunk_size))
+                upload.upload_part_from_file(f, part_num=i+1, size=bytes)
         except:
             upload.cancel_upload()
             raise


### PR DESCRIPTION
r? @alyssafrazee 

### What's in here

This PR implements multipart uploads to avoid the `[Errno 104]` errors from `boto`. It doesn't do anything particularly exciting, I'll point out a few weird things in the code.

This ran successfully on the `trainingbox`s and I was able to see the graphs! (that was about the extent of my test plan, if there's any other things to poke at I can)